### PR TITLE
fix(cli): read version from Go build info

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"github.com/jheddings/ccglow/internal/config"
 	"github.com/jheddings/ccglow/internal/preset"
@@ -16,7 +17,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "dev"
+var version = func() string {
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}()
 
 func main() {
 	var presetName, configPath, format, tee string


### PR DESCRIPTION
## Summary

- `--version` now reads the module version embedded by `go install` via `runtime/debug.ReadBuildInfo`
- Tagged installs (e.g. `go install ...@v0.5.0`) show the real version
- Local builds show the full pseudo-version string
- Falls back to `dev` only when no build info is available

## Test plan

- [x] `go build -o dist/ccglow . && ./dist/ccglow --version` shows pseudo-version
- [ ] `go install github.com/jheddings/ccglow@<tag>` then `ccglow --version` shows the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)