### PR TITLE
feat(render): add provider performance metrics to env

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -3,6 +3,7 @@ package render
 import (
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/jheddings/ccglow/internal/eval"
 	"github.com/jheddings/ccglow/internal/style"
@@ -145,13 +146,21 @@ func BuildEnv(
 		wg.Add(1)
 		go func(prov types.DataProvider) {
 			defer wg.Done()
+			start := time.Now()
 			result, err := prov.Resolve(session)
+			elapsed := time.Since(start)
 			if err != nil {
 				log.Warn().Err(err).Str("provider", prov.Name()).Msg("provider resolve failed")
 				return
 			}
 			mu.Lock()
 			for k, v := range result.Values {
+				// inject __metrics__ into the provider's value subtree
+				if m, ok := v.(map[string]any); ok {
+					m["__metrics__"] = map[string]any{
+						"duration_ms": elapsed.Seconds() * 1000,
+					}
+				}
 				env[k] = v
 			}
 			for k, v := range result.Formats {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -399,6 +399,38 @@ func TestBuildEnv(t *testing.T) {
 	}
 }
 
+func TestBuildEnv_Metrics(t *testing.T) {
+	providers := map[string]types.DataProvider{
+		"test": &testProvider{},
+	}
+	sess := &types.SessionData{CWD: "/tmp"}
+
+	env, _ := BuildEnv(providers, sess)
+
+	test, ok := env["test"].(map[string]any)
+	if !ok {
+		t.Fatal("expected test namespace in env")
+	}
+
+	metrics, ok := test["__metrics__"].(map[string]any)
+	if !ok {
+		t.Fatal("expected __metrics__ in test namespace")
+	}
+
+	duration, ok := metrics["duration_ms"]
+	if !ok {
+		t.Fatal("expected duration_ms in __metrics__")
+	}
+
+	dur, ok := duration.(float64)
+	if !ok {
+		t.Fatalf("expected duration_ms to be float64, got %T", duration)
+	}
+	if dur < 0 {
+		t.Errorf("expected non-negative duration, got %f", dur)
+	}
+}
+
 // testProvider implements DataProvider for tests.
 type testProvider struct{}
 


### PR DESCRIPTION
## Summary
- Times each provider's `Resolve()` call in `BuildEnv()` and injects `__metrics__.duration_ms` into the provider's value subtree
- Always recorded with zero overhead to normal rendering (no preset expressions reference `__metrics__`)
- Visible via `--dump` flag (#56) for debugging provider performance

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `TestBuildEnv_Metrics` — verifies `__metrics__.duration_ms` exists as a non-negative float64
- [x] Existing `TestBuildEnv` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)