### PR TITLE
feat(command): add command segment type for shell execution

### DIFF
--- a/docs/SEGMENTS.md
+++ b/docs/SEGMENTS.md
@@ -125,7 +125,7 @@ Battery segments return zero values on machines without a battery.
 
 ## Node Types
 
-There are two kinds of atomic nodes:
+There are three kinds of atomic nodes:
 
 ### `expr` — Expression nodes
 
@@ -146,6 +146,37 @@ Render a fixed string. Use these for separators, icons, and line breaks.
 { "value": "\n" }
 { "value": "\ue0b0", "style": { "color": "#DC0000", "bgcolor": "#3A3A3A" } }
 ```
+
+### `command` — Shell command nodes
+
+Run a shell command and render its stdout. The command is executed via `sh -c`
+with a 2-second timeout. If the command produces empty output, exits non-zero,
+or times out, the node collapses.
+
+```json
+{ "command": "cat VERSION", "style": { "color": "cyan" } }
+{ "command": "date +%H:%M" }
+```
+
+#### Variable substitution
+
+Use `${provider.field}` to inject resolved provider values into the command
+string. Variables are replaced before execution. Unresolved references become
+empty strings.
+
+```json
+{ "command": "gh pr list --repo ${git.owner}/${git.repo} --json number --jq length", "when": "text != '' && text != '0'" }
+```
+
+#### Behavior
+
+- **Timeout**: Commands have a 2-second timeout. Long-running commands are
+  killed and the node collapses.
+- **Working directory**: Commands run in the session's current working directory.
+- **Collapse**: Empty stdout, non-zero exit, or timeout all cause the node to
+  collapse silently, just like an `expr` node with no data.
+- **Precedence**: If both `expr` and `command` are set on the same node, `expr`
+  wins. The dispatch order is: Children > Value > Expr > Command.
 
 ## Node Properties
 

--- a/docs/WHEN.md
+++ b/docs/WHEN.md
@@ -40,18 +40,22 @@ not just the one that owns the current node.
 ### `value` — Raw data value
 
 The raw value from the expression this node evaluates. The type matches the
-provider field — `int` for counts, `string` for text, etc.
+provider field — `int` for counts, `string` for text, etc. For `command` nodes,
+`value` is the raw stdout string (after whitespace trimming).
 
 ```json
 { "expr": "git.modified", "when": "value > 0" }
+{ "command": "cat VERSION", "when": "value != ''" }
 ```
 
 ### `text` — Formatted display text
 
 The formatted but unstyled text the node would display. Always a string.
+For `command` nodes, `text` is the formatted output (after applying `format`).
 
 ```json
 { "expr": "cost.usd", "when": "text != ''" }
+{ "command": "echo 42", "format": "v%s", "when": "text != ''" }
 ```
 
 ## Operators

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,64 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout is the maximum time a command is allowed to run.
+const DefaultTimeout = 2 * time.Second
+
+var varPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// Interpolate replaces ${dotted.path} references in s by walking the nested
+// env map. Unresolved references are replaced with an empty string.
+func Interpolate(s string, env map[string]any) string {
+	return varPattern.ReplaceAllStringFunc(s, func(match string) string {
+		// Extract the dotted path from ${...}
+		path := varPattern.FindStringSubmatch(match)[1]
+		parts := strings.Split(path, ".")
+
+		var current any = env
+		for _, part := range parts {
+			m, ok := current.(map[string]any)
+			if !ok {
+				return ""
+			}
+			current, ok = m[part]
+			if !ok {
+				return ""
+			}
+		}
+
+		return fmt.Sprintf("%v", current)
+	})
+}
+
+// Run interpolates variables in cmdStr, executes it via sh -c, and returns
+// trimmed stdout. Empty output or non-zero exit returns an empty string.
+func Run(cmdStr string, env map[string]any, cwd string, timeout time.Duration) string {
+	if cmdStr == "" {
+		return ""
+	}
+
+	interpolated := Interpolate(cmdStr, env)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", interpolated)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(out))
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,144 @@
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- Interpolate tests ---
+
+func TestInterpolate_NoVars(t *testing.T) {
+	result := Interpolate("echo hello", nil)
+	if result != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", result)
+	}
+}
+
+func TestInterpolate_SingleVar(t *testing.T) {
+	env := map[string]any{
+		"git": map[string]any{"branch": "main"},
+	}
+	result := Interpolate("git log ${git.branch}", env)
+	if result != "git log main" {
+		t.Errorf("expected 'git log main', got %q", result)
+	}
+}
+
+func TestInterpolate_MultipleVars(t *testing.T) {
+	env := map[string]any{
+		"git": map[string]any{"owner": "jheddings", "repo": "ccglow"},
+	}
+	result := Interpolate("gh pr list --repo ${git.owner}/${git.repo}", env)
+	expected := "gh pr list --repo jheddings/ccglow"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestInterpolate_MissingVar(t *testing.T) {
+	env := map[string]any{}
+	result := Interpolate("echo ${nonexistent.var}", env)
+	if result != "echo " {
+		t.Errorf("expected 'echo ', got %q", result)
+	}
+}
+
+func TestInterpolate_NumericVar(t *testing.T) {
+	env := map[string]any{
+		"test": map[string]any{"count": 42},
+	}
+	result := Interpolate("echo ${test.count}", env)
+	if result != "echo 42" {
+		t.Errorf("expected 'echo 42', got %q", result)
+	}
+}
+
+func TestInterpolate_NilEnv(t *testing.T) {
+	result := Interpolate("echo ${test.val}", nil)
+	if result != "echo " {
+		t.Errorf("expected 'echo ', got %q", result)
+	}
+}
+
+// --- Run tests ---
+
+func TestRun_SimpleEcho(t *testing.T) {
+	result := Run("echo hello", nil, "", DefaultTimeout)
+	if result != "hello" {
+		t.Errorf("expected 'hello', got %q", result)
+	}
+}
+
+func TestRun_EmptyOutputCollapses(t *testing.T) {
+	result := Run("printf ''", nil, "", DefaultTimeout)
+	if result != "" {
+		t.Errorf("expected empty, got %q", result)
+	}
+}
+
+func TestRun_NonZeroExitCollapses(t *testing.T) {
+	result := Run("exit 1", nil, "", DefaultTimeout)
+	if result != "" {
+		t.Errorf("expected empty for non-zero exit, got %q", result)
+	}
+}
+
+func TestRun_TimeoutCollapses(t *testing.T) {
+	result := Run("sleep 10", nil, "", 1) // 1ns timeout
+	if result != "" {
+		t.Errorf("expected empty for timeout, got %q", result)
+	}
+}
+
+func TestRun_WithInterpolation(t *testing.T) {
+	env := map[string]any{
+		"test": map[string]any{"name": "world"},
+	}
+	result := Run("echo ${test.name}", env, "", DefaultTimeout)
+	if result != "world" {
+		t.Errorf("expected 'world', got %q", result)
+	}
+}
+
+func TestRun_TrimsWhitespace(t *testing.T) {
+	result := Run("echo '  hello  '", nil, "", DefaultTimeout)
+	if result != "hello" {
+		t.Errorf("expected 'hello', got %q", result)
+	}
+}
+
+func TestRun_EmptyCommandString(t *testing.T) {
+	result := Run("", nil, "", DefaultTimeout)
+	if result != "" {
+		t.Errorf("expected empty for empty command, got %q", result)
+	}
+}
+
+func TestRun_CWDRespected(t *testing.T) {
+	dir := t.TempDir()
+	// Resolve symlinks to handle macOS /tmp -> /private/tmp
+	dir, _ = filepath.EvalSymlinks(dir)
+
+	result := Run("pwd", nil, dir, DefaultTimeout)
+
+	// Normalize both paths
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	if resultResolved == "" {
+		resultResolved = result
+	}
+
+	if resultResolved != dir {
+		t.Errorf("expected %q, got %q", dir, resultResolved)
+	}
+}
+
+func TestRun_CWDEmptyUsesProcess(t *testing.T) {
+	result := Run("pwd", nil, "", DefaultTimeout)
+	cwd, _ := os.Getwd()
+	cwd, _ = filepath.EvalSymlinks(cwd)
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	if resultResolved != cwd {
+		t.Errorf("expected %q, got %q", cwd, resultResolved)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ func Parse(data []byte) ([]types.SegmentNode, error) {
 		if err := json.Unmarshal(raw, &node); err != nil {
 			continue
 		}
-		if node.Expr == "" && node.Value == nil && len(node.Children) == 0 {
+		if node.Expr == "" && node.Value == nil && node.Command == "" && len(node.Children) == 0 {
 			continue
 		}
 		nodes = append(nodes, node)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,33 @@ func TestParse_WithFormat(t *testing.T) {
 	}
 }
 
+func TestParse_CommandNode(t *testing.T) {
+	input := `{"segments": [{"command": "echo hello", "style": {"color": "cyan"}}]}`
+
+	nodes, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if nodes[0].Command != "echo hello" {
+		t.Errorf("expected command 'echo hello', got %q", nodes[0].Command)
+	}
+}
+
+func TestParse_CommandNodeNotFiltered(t *testing.T) {
+	input := `{"segments": [{"command": "cat VERSION"}, {"expr": "pwd.name"}]}`
+
+	nodes, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes (command not filtered), got %d", len(nodes))
+	}
+}
+
 func TestParse_SkipsEmptyNodes(t *testing.T) {
 	input := `{"segments": [{"style": {"color": "red"}}, {"expr": "pwd.name"}]}`
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jheddings/ccglow/internal/command"
 	"github.com/jheddings/ccglow/internal/eval"
 	"github.com/jheddings/ccglow/internal/style"
 	"github.com/jheddings/ccglow/internal/types"
@@ -78,6 +79,13 @@ func renderNode(
 			return nil
 		}
 		raw = result
+		hasValue = true
+	} else if node.Command != "" {
+		output := command.Run(node.Command, env, session.CWD, command.DefaultTimeout)
+		if output == "" {
+			return nil
+		}
+		raw = output
 		hasValue = true
 	}
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -431,6 +431,125 @@ func TestBuildEnv_Metrics(t *testing.T) {
 	}
 }
 
+// --- Command node tests ---
+
+func TestTree_CommandNode(t *testing.T) {
+	style.SetColorLevel(0)
+	defer style.SetColorLevel(1)
+
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "echo hello"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "hello" {
+		t.Errorf("expected 'hello', got %q", result)
+	}
+}
+
+func TestTree_CommandEmptyCollapses(t *testing.T) {
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "printf ''"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "" {
+		t.Errorf("expected empty (collapsed), got %q", result)
+	}
+}
+
+func TestTree_CommandNonZeroCollapses(t *testing.T) {
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "exit 1"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "" {
+		t.Errorf("expected empty for non-zero exit, got %q", result)
+	}
+}
+
+func TestTree_CommandWithFormat(t *testing.T) {
+	style.SetColorLevel(0)
+	defer style.SetColorLevel(1)
+
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "echo 42", Format: "count: %s"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "count: 42" {
+		t.Errorf("expected 'count: 42', got %q", result)
+	}
+}
+
+func TestTree_CommandWhenPasses(t *testing.T) {
+	style.SetColorLevel(0)
+	defer style.SetColorLevel(1)
+
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "echo hello", When: "text != ''"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "hello" {
+		t.Errorf("expected 'hello', got %q", result)
+	}
+}
+
+func TestTree_CommandWhenFails(t *testing.T) {
+	sess := &types.SessionData{CWD: "/tmp"}
+	tree := []types.SegmentNode{
+		{Command: "echo 0", When: "text != '0'"},
+	}
+
+	result := Tree(tree, sess, map[string]any{}, map[string]string{})
+	if result != "" {
+		t.Errorf("expected empty (when failed), got %q", result)
+	}
+}
+
+func TestTree_CommandWithInterpolation(t *testing.T) {
+	style.SetColorLevel(0)
+	defer style.SetColorLevel(1)
+
+	sess := &types.SessionData{CWD: "/tmp"}
+	env := map[string]any{
+		"test": map[string]any{"name": "world"},
+	}
+	tree := []types.SegmentNode{
+		{Command: "echo ${test.name}"},
+	}
+
+	result := Tree(tree, sess, env, map[string]string{})
+	if result != "world" {
+		t.Errorf("expected 'world', got %q", result)
+	}
+}
+
+func TestTree_ExprTakesPrecedenceOverCommand(t *testing.T) {
+	style.SetColorLevel(0)
+	defer style.SetColorLevel(1)
+
+	sess := &types.SessionData{CWD: "/tmp"}
+	env := map[string]any{
+		"test": map[string]any{"name": "from-expr"},
+	}
+	tree := []types.SegmentNode{
+		{Expr: "test.name", Command: "echo from-command"},
+	}
+
+	result := Tree(tree, sess, env, map[string]string{})
+	if result != "from-expr" {
+		t.Errorf("expected 'from-expr' (expr precedence), got %q", result)
+	}
+}
+
 // testProvider implements DataProvider for tests.
 type testProvider struct{}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -64,6 +64,7 @@ type StyleAttrs struct {
 type SegmentNode struct {
 	Expr     string        `json:"expr,omitempty"`
 	Value    any           `json:"value,omitempty"`
+	Command  string        `json:"command,omitempty"`
 	Format   string        `json:"format,omitempty"`
 	When     string        `json:"when,omitempty"`
 	Enabled  *bool         `json:"enabled,omitempty"`


### PR DESCRIPTION
## Summary

- Adds a `command` segment type that runs a shell command via `sh -c` and renders its trimmed stdout
- Supports `${provider.field}` variable substitution from resolved provider data
- Commands have a 2-second timeout; empty output, non-zero exit, or timeout all collapse the node silently

Closes #45

## Changes

| File | Change |
|---|---|
| `internal/types/types.go` | Add `Command` field to `SegmentNode` |
| `internal/command/command.go` | **New** — `Interpolate` (variable substitution) and `Run` (shell execution) |
| `internal/command/command_test.go` | **New** — 15 unit tests for interpolation and execution |
| `internal/config/config.go` | Update empty-node filter to preserve command-only nodes |
| `internal/config/config_test.go` | 2 new parsing tests |
| `internal/render/render.go` | Add command dispatch branch (precedence: Children > Value > Expr > Command) |
| `internal/render/render_test.go` | 8 new render integration tests |
| `docs/SEGMENTS.md` | Document command node type and variable substitution |
| `docs/WHEN.md` | Note `value`/`text` behavior for command nodes |

## Usage

```json
{ "command": "cat VERSION", "style": { "color": "cyan" } }
{ "command": "gh pr list --repo ${git.owner}/${git.repo} --json number --jq length", "when": "text != '' && text != '0'" }
```

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (25 new tests across 3 packages)
- [x] `go build ./...` passes
- [x] Manual smoke test: `echo '{"cwd":"/tmp"}' | go run . --config <(echo '{"segments":[{"command":"echo hello"}]}')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)